### PR TITLE
Add CICD workflow

### DIFF
--- a/.github/workflows/promsnmp-build.yaml
+++ b/.github/workflows/promsnmp-build.yaml
@@ -1,0 +1,45 @@
+---
+name: promsnmp-build
+run-name: Build and run test suites
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      - name: Set version number, data and short git hash
+        run: |
+          echo "VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> ${GITHUB_ENV}
+          echo "SHORT_GIT_SHA=$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
+          echo "BUILD_DATE"=$(date -u +"%Y-%m-%dT%H:%M:%SZ") >> ${GITHUB_ENV}
+      - name: Build and run tests
+        run: make
+      - name: Persist JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: promsnmp-jar
+          path: |
+            target/*.jar
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build container image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          build-args: |
+            DATE=${{ env.BUILD_DATE }}
+            GIT_SHORT_HASH=${{ env.SHORT_GIT_SHA }}
+            VERSION=${{ env.VERSION }}
+          tags: promsnmp:${{ env.SHORT_GIT_SHA }}

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ node_modules/
 *.tmp
 *.~*
 
+### jenv tool
+.java-version
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,45 @@
-# Set the base image
-FROM eclipse-temurin:21-jdk-noble AS builder
-
-# Set the working directory
-WORKDIR /app
-
-# Copy Maven wrapper and configuration
-COPY mvnw .
-COPY .mvn .mvn
-
-# Copy the project files
-COPY pom.xml .
-COPY src ./src
-
-# Ensure the Maven wrapper script is executable
-RUN chmod +x mvnw
-
-# Build the application
-RUN ./mvnw clean package -DskipTests -P container-build
-
 # Final image
 FROM eclipse-temurin:21-jdk-noble
 
 # Install handy utilites and clean up apt cache
-RUN apt-get update && apt-get install -y reptyr dnsutils bind9-utils net-tools iproute2 iputils-ping iputils-tracepath ncat && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y \
+      bind9-utils \
+      dnsutils \
+      iproute2 \
+      iputils-ping \
+      iputils-tracepath \
+      ncat \
+      net-tools \
+      reptyr && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-#The Maven container-build profile sets the final name of the JAR to "app.jar"
-COPY --from=builder /app/target/app.jar app.jar
-ENTRYPOINT ["java", "-jar", "app.jar"]
+# Invalidate build cache only when we have changed the code
+ARG VERSION
+ARG GIT_SHORT_HASH
+
+COPY target/promsnmp-*.jar /app/promsnmp.jar
+
+# Set the working directory
+WORKDIR /app
+
+ENTRYPOINT ["java"]
+
+CMD ["-jar", "promsnmp.jar"]
+
+# Invalidate only the cache for the layer with labels when we rebuild the same code
+ARG DATE="1970-01-01T00:00:00Z"
+
+LABEL org.opencontainers.image.created="${DATE}" \
+      org.opencontainers.image.authors="TBD" \
+      org.opencontainers.image.url="TBD" \
+      org.opencontainers.image.source="https://github.com/pbrane/PromSNMP" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${GIT_SHORT_HASH}" \
+      org.opencontainers.image.vendor="pbrane" \
+      org.opencontainers.image.licenses="TBD"
+
+## Runtime information for exposing metrics on port 8080/tcp by default
+
+EXPOSE 8080/tcp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+.DEFAULT_GOAL := promsnmp
+
+SHELL               := /bin/bash -o nounset -o pipefail -o errexit
+VERSION             ?= $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+GIT_BRANCH          := $(shell git branch --show-current)
+GIT_SHORT_HASH      := $(shell git rev-parse --short HEAD)
+OCI_TAG             := local/promsnmp:$(VERSION)
+DATE                := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ") # Date format RFC3339
+JAVA_MAJOR_VERSION  := 21
+
+.PHONY help:
+help:
+	@echo ""
+	@echo "Build PromSNMP from source"
+	@echo "Goals:"
+	@echo "  help:         Show this help with explaining the build goals"
+	@echo "  promsnmp      Compile, assemble and run test suite"
+	@echo "  clean:        Clean the build artifacts"
+	@echo ""
+
+.PHONY deps-build:
+deps-build:
+	command -v java
+	command -v javac
+	command -v mvn
+	@java --version
+	@echo "Check Java version $(JAVA_MAJOR_VERSION)"
+	@java --version | grep '21\.[[:digit:]]*\.[[:digit:]]*' >/dev/null
+
+.PHONY deps-oci:
+deps-oci:
+	command -v docker
+
+.PHONY promsnmp:
+promsnmp: deps-build
+	mvn --batch-mode --update-snapshots verify
+
+.PHONY oci:
+oci: deps-oci promsnmp
+	docker build -t $(OCI_TAG) \
+      --build-arg="VERSION=$(VERSION)" \
+      --build-arg="GIT_SHORT_HASH"=$(GIT_SHORT_HASH) \
+      --build-arg="DATE=$(DATE)" \
+      .
+
+.PHONY clean:
+clean: deps-build
+	mvn clean

--- a/README.md
+++ b/README.md
@@ -1,4 +1,39 @@
-# PromSNMP
+# PromSNMP [![promsnmp-build](https://github.com/pbrane/PromSNMP/actions/workflows/promsnmp-build.yaml/badge.svg)](https://github.com/pbrane/PromSNMP/actions/workflows/promsnmp-build.yaml)
+
+
+## 👩‍🏭 Build from source
+
+Check out the source code with
+
+```shell
+git clone https://github.com/pbrane/PromSNMP.git
+```
+
+Compile and assemble the JAR file including the test suite
+
+```shell
+make
+```
+
+Build a Docker container image in your local registry
+
+```shell
+make oci
+```
+
+## 🕹️ Run the application
+
+Start the application locally
+
+```shell
+java -jar target/promsnmp-*.jar
+```
+
+Start the application using Docker
+
+```shell
+docker run --rm -p "8082:8080/tcp" local/promsnmp:0.0.1-SNAPSHOT
+```
 
 ## https://start.spring.io 
 <img width="1354" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/6f16a6de-af22-493b-8b3f-813c681fe273" />


### PR DESCRIPTION
I added a Makefile and a README to build it from the source, including a Docker image. Added a GitHub action workflow, which creates the JAR and persists it as a build artifact.
Create a build job that creates a Docker image to run natively on x86_64 and arm64 on Apple Silicon.

## Reviewers hint
I don't push the Docker container image to a registry. I don't know where to push it or with which credentials. Adding these pieces is trivial from here.