### PR TITLE
fix: Disable shell for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ deps-oci:
 
 .PHONY promsnmp:
 promsnmp: deps-build
-	mvn --batch-mode --update-snapshots verify
+	mvn --batch-mode -Dspring.shell.interactive.enabled="false" --update-snapshots verify
 
 .PHONY oci:
 oci: deps-oci promsnmp


### PR DESCRIPTION
When the shell is enabled for the test suite, it fails. I've disabled the interactive shell just for tests.