### PR TITLE
feat: Publish docker images to GitHub container registry

### DIFF
--- a/.github/workflows/promsnmp-build.yaml
+++ b/.github/workflows/promsnmp-build.yaml
@@ -32,14 +32,20 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
       - name: Build container image
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: false
+          push: true
           build-args: |
             DATE=${{ env.BUILD_DATE }}
             GIT_SHORT_HASH=${{ env.SHORT_GIT_SHA }}
             VERSION=${{ env.VERSION }}
-          tags: promsnmp:${{ env.SHORT_GIT_SHA }}
+          tags: ghcr.io/pbrane/promsnmp:${{ env.SHORT_GIT_SHA }}

--- a/.github/workflows/promsnmp-build.yaml
+++ b/.github/workflows/promsnmp-build.yaml
@@ -36,8 +36,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build container image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/promsnmp-build.yaml
+++ b/.github/workflows/promsnmp-build.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
       - name: Build container image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
Create and push a container image tagged with the unique GitHub short hash number to ghcr.io of the project.

Resolve: #10

# Reviewer Hint

Before we can merge this PR we need a classic personal access token (PAT) with read/write/delete permissions for this repository. The PAT needs to be created as an Action "Secret" with the variable name `GHCR_PAT`. The build fails right now with an authentication error against the GitHub container registry.