### PR TITLE
Resource based prom snmp service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,22 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/caffeine -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>3.2.0</version>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/src/main/java/org/promsnmp/promsnmp/PromSnmp.java
+++ b/src/main/java/org/promsnmp/promsnmp/PromSnmp.java
@@ -2,8 +2,12 @@ package org.promsnmp.promsnmp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableCaching
+@EnableScheduling
 public class PromSnmp {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/promsnmp/promsnmp/commands/PromSnmpCommands.java
+++ b/src/main/java/org/promsnmp/promsnmp/commands/PromSnmpCommands.java
@@ -26,13 +26,13 @@ public class PromSnmpCommands {
             @ShellOption(defaultValue = "false", help = "Treat the instance filter as a regular expression.") boolean regex,
             @ShellOption(defaultValue = ShellOption.NULL, help = "Optional instance name to filter (e.g., router-1.example.com)") String instance
     ) {
-        return promSnmpService.readMetrics(instance, regex);
+        return promSnmpService.getMetrics(instance, regex);
     }
 
 
     @ShellMethod(key = "services", value = "Displays services from prometheus-snmp-services.json")
     public String sampleServices() {
-        return promSnmpService.readServices()
+        return promSnmpService.getServices()
                 .orElse("{\"error\": \"File not found\"}");
     }
 }

--- a/src/main/java/org/promsnmp/promsnmp/commands/PromSnmpCommands.java
+++ b/src/main/java/org/promsnmp/promsnmp/commands/PromSnmpCommands.java
@@ -1,6 +1,7 @@
 package org.promsnmp.promsnmp.commands;
 
 import org.promsnmp.promsnmp.services.PromSnmpService;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.shell.standard.ShellComponent;
 import org.springframework.shell.standard.ShellMethod;
 import org.springframework.shell.standard.ShellOption;
@@ -12,7 +13,7 @@ public class PromSnmpCommands {
 
     private final PromSnmpService promSnmpService;
 
-    public PromSnmpCommands(PromSnmpService promSnmpService) {
+    public PromSnmpCommands(@Qualifier("configuredService") PromSnmpService promSnmpService) {
         this.promSnmpService = promSnmpService;
     }
 

--- a/src/main/java/org/promsnmp/promsnmp/commands/PromSnmpCommands.java
+++ b/src/main/java/org/promsnmp/promsnmp/commands/PromSnmpCommands.java
@@ -2,19 +2,24 @@ package org.promsnmp.promsnmp.commands;
 
 import org.promsnmp.promsnmp.services.PromSnmpService;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.CacheManager;
 import org.springframework.shell.standard.ShellComponent;
 import org.springframework.shell.standard.ShellMethod;
 import org.springframework.shell.standard.ShellOption;
 
+import java.util.Objects;
 import java.util.Optional;
 
 @ShellComponent
 public class PromSnmpCommands {
 
     private final PromSnmpService promSnmpService;
+    private final CacheManager cacheManager;
 
-    public PromSnmpCommands(@Qualifier("configuredService") PromSnmpService promSnmpService) {
+
+    public PromSnmpCommands(@Qualifier("configuredService") PromSnmpService promSnmpService, CacheManager cacheManager) {
         this.promSnmpService = promSnmpService;
+        this.cacheManager = cacheManager;
     }
 
     @ShellMethod(key = "hello", value = "Returns a greeting message.")
@@ -23,17 +28,26 @@ public class PromSnmpCommands {
     }
 
     @ShellMethod(key = "metrics", value = "Displays sample metric data, optionally filtered by instance name.")
-    public Optional<String> demoData(
+    public Optional<String> metrics(
             @ShellOption(defaultValue = "false", help = "Treat the instance filter as a regular expression.") boolean regex,
-            @ShellOption(defaultValue = ShellOption.NULL, help = "Optional instance name to filter (e.g., router-1.example.com)") String instance
-    ) {
+            @ShellOption(defaultValue = ShellOption.NULL, help = "Optional instance name to filter (e.g., router-1.example.com)") String instance) {
+
+        if (instance == null || instance.isBlank()) {
+            return Optional.of("Please provide a valid instance name.");
+        }
         return promSnmpService.getMetrics(instance, regex);
     }
-
 
     @ShellMethod(key = "services", value = "Displays services from prometheus-snmp-services.json")
     public String sampleServices() {
         return promSnmpService.getServices()
                 .orElse("{\"error\": \"File not found\"}");
     }
+
+    @ShellMethod(key = "evictCache", value = "Evict all cached metrics")
+    public String evictAll() {
+        Objects.requireNonNull(cacheManager.getCache("metrics")).clear();
+        return "Cache cleared.";
+    }
+
 }

--- a/src/main/java/org/promsnmp/promsnmp/configuration/CacheConfig.java
+++ b/src/main/java/org/promsnmp/promsnmp/configuration/CacheConfig.java
@@ -1,0 +1,37 @@
+package org.promsnmp.promsnmp.configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Value("${CACHE_EXP_MILLIS:300000}")
+    private Integer cacheExp;
+
+    @Value("${CACHE_ENTRY_CNT:10000}")
+    private Integer cacheEntries;
+
+    @Bean
+    public Caffeine<Object, Object> caffeineConfig() {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(cacheExp, TimeUnit.MILLISECONDS)  // Cache TTL
+                .maximumSize(cacheEntries)
+                .recordStats();                     // Optional: limit entries
+    }
+
+    @Bean
+    public CacheManager cacheManager(Caffeine<Object, Object> caffeine) {
+        CaffeineCacheManager manager = new CaffeineCacheManager("metrics");
+        manager.setCaffeine(caffeine);
+        return manager;
+    }
+}

--- a/src/main/java/org/promsnmp/promsnmp/configuration/ServiceApiConfig.java
+++ b/src/main/java/org/promsnmp/promsnmp/configuration/ServiceApiConfig.java
@@ -1,7 +1,11 @@
 package org.promsnmp.promsnmp.configuration;
 
+import org.promsnmp.promsnmp.repositories.PromSnmpRepository;
+import org.promsnmp.promsnmp.repositories.demo.DemoRepository;
+import org.promsnmp.promsnmp.repositories.resource.ClassPathResourcePromSnmpRepository;
 import org.promsnmp.promsnmp.services.PromSnmpService;
 import org.promsnmp.promsnmp.services.demo.PromSnmpServiceDemo;
+import org.promsnmp.promsnmp.services.resource.ResourceBasedPromSnmpService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,13 +16,24 @@ public class ServiceApiConfig {
     @Value("${SERVICE_API:demo}")
     private String apiSvcMode;
 
-    @Bean
-    public PromSnmpService promSnmpService(PromSnmpServiceDemo demoService) {
-        if ("demo".equalsIgnoreCase(apiSvcMode)) {
-            return demoService;
-        } else {
-            throw new IllegalStateException("No configured PromSnmpService.");
-        }
+    @Value("${REPOSITORY_API:demo}")
+    private String apiRepoMode;
+
+    @Bean("configuredService")
+    public PromSnmpService promSnmpService(PromSnmpServiceDemo demoService, ResourceBasedPromSnmpService resourceService) {
+        return switch (apiSvcMode.toLowerCase()) {
+            case "demo" -> demoService;
+            case "resource" -> resourceService;
+            default -> throw new IllegalStateException("Unknown SERVICE_API mode: " + apiSvcMode);
+        };
     }
 
+    @Bean("configuredRepo")
+    public PromSnmpRepository promSnmpRepository(ClassPathResourcePromSnmpRepository classPathResourcePromSnmpRepository, DemoRepository demoRepository) {
+        return switch (apiRepoMode.toLowerCase()) {
+            case "classpath" -> classPathResourcePromSnmpRepository;
+            case "demo" -> demoRepository;
+            default -> throw new IllegalStateException("Unknown REPOSITORY_API mode");
+        };
+    }
 }

--- a/src/main/java/org/promsnmp/promsnmp/configuration/ServiceApiConfig.java
+++ b/src/main/java/org/promsnmp/promsnmp/configuration/ServiceApiConfig.java
@@ -31,8 +31,8 @@ public class ServiceApiConfig {
     @Bean("configuredRepo")
     public PromSnmpRepository promSnmpRepository(ClassPathResourcePromSnmpRepository classPathResourcePromSnmpRepository, DemoRepository demoRepository) {
         return switch (apiRepoMode.toLowerCase()) {
-            case "classpath" -> classPathResourcePromSnmpRepository;
             case "demo" -> demoRepository;
+            case "classpath" -> classPathResourcePromSnmpRepository;
             default -> throw new IllegalStateException("Unknown REPOSITORY_API mode");
         };
     }

--- a/src/main/java/org/promsnmp/promsnmp/configuration/ServiceApiConfig.java
+++ b/src/main/java/org/promsnmp/promsnmp/configuration/ServiceApiConfig.java
@@ -4,8 +4,7 @@ import org.promsnmp.promsnmp.repositories.PromSnmpRepository;
 import org.promsnmp.promsnmp.repositories.demo.DemoRepository;
 import org.promsnmp.promsnmp.repositories.resource.ClassPathResourcePromSnmpRepository;
 import org.promsnmp.promsnmp.services.PromSnmpService;
-import org.promsnmp.promsnmp.services.demo.PromSnmpServiceDemo;
-import org.promsnmp.promsnmp.services.resource.ResourceBasedPromSnmpService;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,14 +12,14 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ServiceApiConfig {
 
-    @Value("${SERVICE_API:demo}")
+    @Value("${SVC_API:demo}")
     private String apiSvcMode;
 
-    @Value("${REPOSITORY_API:demo}")
+    @Value("${REPO_API:demo}")
     private String apiRepoMode;
 
     @Bean("configuredService")
-    public PromSnmpService promSnmpService(PromSnmpServiceDemo demoService, ResourceBasedPromSnmpService resourceService) {
+    public PromSnmpService promSnmpService(@Qualifier("DemoSvc") PromSnmpService demoService, @Qualifier("ResSvc") PromSnmpService resourceService) {
         return switch (apiSvcMode.toLowerCase()) {
             case "demo" -> demoService;
             case "resource" -> resourceService;
@@ -29,10 +28,10 @@ public class ServiceApiConfig {
     }
 
     @Bean("configuredRepo")
-    public PromSnmpRepository promSnmpRepository(ClassPathResourcePromSnmpRepository classPathResourcePromSnmpRepository, DemoRepository demoRepository) {
+    public PromSnmpRepository promSnmpRepository(@Qualifier("DemoRepo") PromSnmpRepository demoRepository, @Qualifier("ClassPathRepo") PromSnmpRepository cpRepo) {
         return switch (apiRepoMode.toLowerCase()) {
             case "demo" -> demoRepository;
-            case "classpath" -> classPathResourcePromSnmpRepository;
+            case "classpath" -> cpRepo;
             default -> throw new IllegalStateException("Unknown REPOSITORY_API mode");
         };
     }

--- a/src/main/java/org/promsnmp/promsnmp/configuration/ServiceApiConfig.java
+++ b/src/main/java/org/promsnmp/promsnmp/configuration/ServiceApiConfig.java
@@ -1,8 +1,6 @@
 package org.promsnmp.promsnmp.configuration;
 
 import org.promsnmp.promsnmp.repositories.PromSnmpRepository;
-import org.promsnmp.promsnmp.repositories.demo.DemoRepository;
-import org.promsnmp.promsnmp.repositories.resource.ClassPathResourcePromSnmpRepository;
 import org.promsnmp.promsnmp.services.PromSnmpService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/org/promsnmp/promsnmp/controllers/DemoController.java
+++ b/src/main/java/org/promsnmp/promsnmp/controllers/DemoController.java
@@ -1,6 +1,7 @@
 package org.promsnmp.promsnmp.controllers;
 
 import org.promsnmp.promsnmp.services.PromSnmpService;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -16,7 +17,7 @@ public class DemoController {
 
     private final PromSnmpService promSnmpService;
 
-    public DemoController(PromSnmpService promSnmpService) {
+    public DemoController(@Qualifier("configuredService") PromSnmpService promSnmpService) {
         this.promSnmpService = promSnmpService;
     }
 
@@ -32,7 +33,7 @@ public class DemoController {
             @RequestParam(required = false, defaultValue = "false")
             Boolean regex ) {
 
-        return promSnmpService.readMetrics(instance, regex)
+        return promSnmpService.getMetrics(instance, regex)
                 .map(metrics -> ResponseEntity.ok()
                         .header(HttpHeaders.CONTENT_TYPE, "text/plain; charset=UTF-8")
                         .body(metrics))
@@ -42,7 +43,7 @@ public class DemoController {
 
     @GetMapping("/services")
     public ResponseEntity<String> sampleServices() {
-        return promSnmpService.readServices()
+        return promSnmpService.getServices()
                 .map(services -> ResponseEntity.ok()
                         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                         .body(services))

--- a/src/main/java/org/promsnmp/promsnmp/controllers/PromSnmpController.java
+++ b/src/main/java/org/promsnmp/promsnmp/controllers/PromSnmpController.java
@@ -2,6 +2,7 @@ package org.promsnmp.promsnmp.controllers;
 
 import org.promsnmp.promsnmp.services.PromSnmpService;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.CacheManager;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -11,14 +12,18 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Objects;
+
 @RestController
 @RequestMapping("/promSnmp")
 public class PromSnmpController {
 
     private final PromSnmpService promSnmpService;
+    private final CacheManager cacheManager;
 
-    public PromSnmpController(@Qualifier("configuredService") PromSnmpService promSnmpService) {
+    public PromSnmpController(@Qualifier("configuredService") PromSnmpService promSnmpService, CacheManager cacheManager) {
         this.promSnmpService = promSnmpService;
+        this.cacheManager = cacheManager;
     }
 
     @GetMapping("/hello")
@@ -49,5 +54,11 @@ public class PromSnmpController {
                         .body(services))
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.BAD_REQUEST)
                         .body("{\"error\": \"File not found\"}"));
+    }
+
+    @GetMapping("/evictCache")
+    public String evictAll() {
+        Objects.requireNonNull(cacheManager.getCache("metrics")).clear();
+        return "Cache cleared.";
     }
 }

--- a/src/main/java/org/promsnmp/promsnmp/controllers/PromSnmpController.java
+++ b/src/main/java/org/promsnmp/promsnmp/controllers/PromSnmpController.java
@@ -13,11 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/promSnmp")
-public class DemoController {
+public class PromSnmpController {
 
     private final PromSnmpService promSnmpService;
 
-    public DemoController(@Qualifier("configuredService") PromSnmpService promSnmpService) {
+    public PromSnmpController(@Qualifier("configuredService") PromSnmpService promSnmpService) {
         this.promSnmpService = promSnmpService;
     }
 

--- a/src/main/java/org/promsnmp/promsnmp/monitoring/CacheMonitor.java
+++ b/src/main/java/org/promsnmp/promsnmp/monitoring/CacheMonitor.java
@@ -1,0 +1,27 @@
+package org.promsnmp.promsnmp.monitoring;
+
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CacheMonitor {
+
+    private final CacheManager cacheManager;
+
+    public CacheMonitor(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    @Scheduled(fixedRateString = "${CACHE_STATS_RATE_MILLIS:60000}")
+    public void logCacheStats() {
+        CaffeineCache metricsCache = (CaffeineCache) cacheManager.getCache("metrics");
+        if (metricsCache == null) return;
+
+        CacheStats stats = metricsCache.getNativeCache().stats();
+        System.out.println("[CacheMonitor] Metrics Cache Stats: " + stats.toString());
+    }
+}

--- a/src/main/java/org/promsnmp/promsnmp/repositories/PromSnmpRepository.java
+++ b/src/main/java/org/promsnmp/promsnmp/repositories/PromSnmpRepository.java
@@ -4,7 +4,7 @@ import org.springframework.core.io.Resource;
 
 public interface PromSnmpRepository {
 
-    public Resource readMetrics(String instance);
-    public Resource readServices();
+    Resource readMetrics(String instance);
+    Resource readServices();
 
 }

--- a/src/main/java/org/promsnmp/promsnmp/repositories/PromSnmpRepository.java
+++ b/src/main/java/org/promsnmp/promsnmp/repositories/PromSnmpRepository.java
@@ -1,11 +1,10 @@
 package org.promsnmp.promsnmp.repositories;
 
-import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.Resource;
 
 public interface PromSnmpRepository {
 
-    public Resource getMetricsResource();
-    public Resource getServicesResource();
+    public Resource readMetrics(String instance);
+    public Resource readServices();
 
 }

--- a/src/main/java/org/promsnmp/promsnmp/repositories/demo/DemoRepository.java
+++ b/src/main/java/org/promsnmp/promsnmp/repositories/demo/DemoRepository.java
@@ -5,16 +5,16 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Repository;
 
-@Repository
+@Repository("DemoRepo")
 public class DemoRepository implements PromSnmpRepository {
 
     @Override
-    public Resource getMetricsResource() {
+    public Resource readMetrics(String instance) {
         return new ClassPathResource("static/prometheus-snmp-export.dat");
     }
 
     @Override
-    public Resource getServicesResource() {
+    public Resource readServices() {
         return new ClassPathResource("static/prometheus-snmp-services.json");
     }
 }

--- a/src/main/java/org/promsnmp/promsnmp/repositories/resource/ClassPathResourcePromSnmpRepository.java
+++ b/src/main/java/org/promsnmp/promsnmp/repositories/resource/ClassPathResourcePromSnmpRepository.java
@@ -1,0 +1,22 @@
+package org.promsnmp.promsnmp.repositories.resource;
+
+import org.promsnmp.promsnmp.repositories.PromSnmpRepository;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Repository;
+
+@Repository("ClassPathRepo")
+public class ClassPathResourcePromSnmpRepository implements PromSnmpRepository {
+
+    @Override
+    public Resource readMetrics(String instance) {
+        // default file (could be null)
+        return new ClassPathResource("metrics/" + instance + ".prom");
+    }
+
+    @Override
+    public Resource readServices() {
+        return new ClassPathResource("services/prometheus-snmp-services.json");
+    }
+
+}

--- a/src/main/java/org/promsnmp/promsnmp/services/PromSnmpService.java
+++ b/src/main/java/org/promsnmp/promsnmp/services/PromSnmpService.java
@@ -3,7 +3,7 @@ package org.promsnmp.promsnmp.services;
 import java.util.Optional;
 
 public interface PromSnmpService {
-    Optional<String> readServices();
+    Optional<String> getServices();
 
-    Optional<String> readMetrics(String instance, boolean regex);
+    Optional<String> getMetrics(String instance, boolean regex);
 }

--- a/src/main/java/org/promsnmp/promsnmp/services/cache/CachedMetricsService.java
+++ b/src/main/java/org/promsnmp/promsnmp/services/cache/CachedMetricsService.java
@@ -1,0 +1,42 @@
+package org.promsnmp.promsnmp.services.cache;
+
+import org.promsnmp.promsnmp.repositories.PromSnmpRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class CachedMetricsService {
+
+    private final PromSnmpRepository repository;
+
+    public CachedMetricsService(@Qualifier("configuredRepo") PromSnmpRepository repository) {
+        this.repository = repository;
+    }
+
+    @Cacheable(value = "metrics", key = "#instance")
+    public Optional<String> getRawMetrics(String instance) {
+        if (instance == null || instance.isBlank()) {
+            return Optional.empty();  // 🚫 don't cache null or blank instances
+        }
+
+        Resource instanceResource = repository.readMetrics(instance);
+        if (!instanceResource.exists()) {
+            return Optional.empty();
+        }
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(instanceResource.getInputStream(), StandardCharsets.UTF_8))) {
+            return Optional.of(reader.lines().collect(Collectors.joining("\n")));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/org/promsnmp/promsnmp/services/demo/DemoPromSnmpService.java
+++ b/src/main/java/org/promsnmp/promsnmp/services/demo/DemoPromSnmpService.java
@@ -17,12 +17,12 @@ import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@Service
-public class PromSnmpServiceDemo implements PromSnmpService {
+@Service("DemoSvc")
+public class DemoPromSnmpService implements PromSnmpService {
 
     private final PromSnmpRepository demoRepository;
 
-    public PromSnmpServiceDemo(@Qualifier("configuredRepo") PromSnmpRepository repository) {
+    public DemoPromSnmpService(@Qualifier("configuredRepo") PromSnmpRepository repository) {
         this.demoRepository = repository;
     }
 

--- a/src/main/java/org/promsnmp/promsnmp/services/resource/ResourceBasedPromSnmpService.java
+++ b/src/main/java/org/promsnmp/promsnmp/services/resource/ResourceBasedPromSnmpService.java
@@ -16,7 +16,7 @@ import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@Service
+@Service("ResSvc")
 public class ResourceBasedPromSnmpService implements PromSnmpService {
 
     private final PromSnmpRepository repository;

--- a/src/main/resources/metrics/router-1.example.com.prom
+++ b/src/main/resources/metrics/router-1.example.com.prom
@@ -1,0 +1,54 @@
+
+# HELP ifHCInOctets The total number of octets received on the interface (High Capacity).
+# TYPE ifHCInOctets counter
+ifHCInOctets{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 12345678901234
+ifHCInOctets{instance="router-1.example.com", ifIndex="2", ifDescr="GigabitEthernet0/1", ifName="Gig0/1", ifAlias="Uplink to Server"} 23456789012345
+
+# HELP ifHCOutOctets The total number of octets transmitted out of the interface (High Capacity).
+# TYPE ifHCOutOctets counter
+ifHCOutOctets{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 22334455667788
+ifHCOutOctets{instance="router-1.example.com", ifIndex="2", ifDescr="GigabitEthernet0/1", ifName="Gig0/1", ifAlias="Uplink to Server"} 33445566778899
+
+# HELP ifHCInUcastPkts Number of unicast packets received.
+# TYPE ifHCInUcastPkts counter
+ifHCInUcastPkts{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 87654321
+
+# HELP ifHCOutUcastPkts Number of unicast packets transmitted.
+# TYPE ifHCOutUcastPkts counter
+ifHCOutUcastPkts{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 76543210
+
+# HELP ifHCInMulticastPkts Number of multicast packets received.
+# TYPE ifHCInMulticastPkts counter
+ifHCInMulticastPkts{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 3456789
+
+# HELP ifHCOutMulticastPkts Number of multicast packets transmitted.
+# TYPE ifHCOutMulticastPkts counter
+ifHCOutMulticastPkts{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 2345678
+
+# HELP ifHCInBroadcastPkts Number of broadcast packets received.
+# TYPE ifHCInBroadcastPkts counter
+ifHCInBroadcastPkts{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 123456
+
+# HELP ifHCOutBroadcastPkts Number of broadcast packets transmitted.
+# TYPE ifHCOutBroadcastPkts counter
+ifHCOutBroadcastPkts{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 112233
+
+# HELP ifInDiscards Number of inbound packets discarded.
+# TYPE ifInDiscards counter
+ifInDiscards{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 10
+
+# HELP ifInErrors Number of inbound packets with errors.
+# TYPE ifInErrors counter
+ifInErrors{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 5
+
+# HELP ifOutDiscards Number of outbound packets discarded.
+# TYPE ifOutDiscards counter
+ifOutDiscards{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 8
+
+# HELP ifOutErrors Number of outbound packets with errors.
+# TYPE ifOutErrors counter
+ifOutErrors{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 2
+
+# HELP ifHighSpeed Interface speed in Mbps.
+# TYPE ifHighSpeed gauge
+ifHighSpeed{instance="router-1.example.com", ifIndex="1", ifDescr="GigabitEthernet0/0", ifName="Gig0/0", ifAlias="WAN Link"} 1000

--- a/src/main/resources/metrics/switch-1.example.com.prom
+++ b/src/main/resources/metrics/switch-1.example.com.prom
@@ -1,0 +1,54 @@
+
+# HELP ifHCInOctets The total number of octets received on the interface (High Capacity).
+# TYPE ifHCInOctets counter
+ifHCInOctets{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 98765432101234
+ifHCInOctets{instance="switch-1.example.com", ifIndex="2", ifDescr="FastEthernet1/0/2", ifName="Fa1/0/2", ifAlias="Uplink to ISP"} 87654321012345
+
+# HELP ifHCOutOctets The total number of octets transmitted out of the interface (High Capacity).
+# TYPE ifHCOutOctets counter
+ifHCOutOctets{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 11223344556677
+ifHCOutOctets{instance="switch-1.example.com", ifIndex="2", ifDescr="FastEthernet1/0/2", ifName="Fa1/0/2", ifAlias="Uplink to ISP"} 77889900112233
+
+# HELP ifHCInUcastPkts Number of unicast packets received.
+# TYPE ifHCInUcastPkts counter
+ifHCInUcastPkts{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 98765432
+
+# HELP ifHCOutUcastPkts Number of unicast packets transmitted.
+# TYPE ifHCOutUcastPkts counter
+ifHCOutUcastPkts{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 87654321
+
+# HELP ifHCInMulticastPkts Number of multicast packets received.
+# TYPE ifHCInMulticastPkts counter
+ifHCInMulticastPkts{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 4567890
+
+# HELP ifHCOutMulticastPkts Number of multicast packets transmitted.
+# TYPE ifHCOutMulticastPkts counter
+ifHCOutMulticastPkts{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 3456789
+
+# HELP ifHCInBroadcastPkts Number of broadcast packets received.
+# TYPE ifHCInBroadcastPkts counter
+ifHCInBroadcastPkts{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 234567
+
+# HELP ifHCOutBroadcastPkts Number of broadcast packets transmitted.
+# TYPE ifHCOutBroadcastPkts counter
+ifHCOutBroadcastPkts{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 223344
+
+# HELP ifInDiscards Number of inbound packets discarded.
+# TYPE ifInDiscards counter
+ifInDiscards{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 20
+
+# HELP ifInErrors Number of inbound packets with errors.
+# TYPE ifInErrors counter
+ifInErrors{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 3
+
+# HELP ifOutDiscards Number of outbound packets discarded.
+# TYPE ifOutDiscards counter
+ifOutDiscards{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 15
+
+# HELP ifOutErrors Number of outbound packets with errors.
+# TYPE ifOutErrors counter
+ifOutErrors{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 4
+
+# HELP ifHighSpeed Interface speed in Mbps.
+# TYPE ifHighSpeed gauge
+ifHighSpeed{instance="switch-1.example.com", ifIndex="1", ifDescr="FastEthernet1/0/1", ifName="Fa1/0/1", ifAlias="Uplink to Core"} 100


### PR DESCRIPTION
1. New Repository layer added
2. New ClassPathResource Service Layer Impl added that takes the instance parameter (both for the URL and Shell Command) and outputs the content of a file with same name as the instance + ".prom" (file extension)
3. New ServiceLayer Metrics Caching!

### How to:
```$ SVC_API=resource REPO_API=classpath CACHE_STATS_RATE_MILLIS=60000 CACHE_EXP_MILLIS=300000 CACHE_ENTRY_CNT=10000 ./mvnw spring-boot:run```

### Cache Stats:
CacheStats from my test (9 cache hits!)
Metrics Cache Stats: CacheStats{hitCount=9, missCount=1, loadSuccessCount=0, loadFailureCount=0, totalLoadTime=0, evictionCount=0, evictionWeight=0}

### Examples:
#### Built-in Spring Shell:
```
shell:>metrics --instance router-1.example.com
shell:>metrics --instance switch-1.example.com
```
#### REST
http://localhost:8080/promSnmp/metrics?instance=router-1.example.com
http://localhost:8080/promSnmp/metrics?instance=switch-1.example.com
```